### PR TITLE
Update ReactTurboRater.jsx

### DIFF
--- a/src/ReactTurboRater.jsx
+++ b/src/ReactTurboRater.jsx
@@ -56,7 +56,7 @@ class ReactTurboRater extends React.Component {
             contentDocument.head.appendChild(myscript);
         };
     }
-    handlePageLoad(page) {
+    handlePageLoad = (page) => {
         const pageId = page
             .split('/')
             .pop()


### PR DESCRIPTION
seems like handlePageLoad needs to bind since it requires `this.props`
@napalm272 